### PR TITLE
Feature/dce 3116

### DIFF
--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -71,7 +71,7 @@ module.exports = class {
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
-        const stringTypeDef = (length === 0) ? DataTypes.TEXT : DataTypes.STRING(length);
+        const stringTypeDef = (length === 0) ? DataTypes.TEXT('long') : DataTypes.STRING(length);
         this[attributeName] = {
           type: stringTypeDef,
           allowNull: true

--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -71,7 +71,7 @@ module.exports = class {
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
-        const stringTypeDef = (length === 0) ? DataTypes.TEXT('long') : DataTypes.STRING(length);
+        const stringTypeDef = (length && length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT('long');
         this[attributeName] = {
           type: stringTypeDef,
           allowNull: true

--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -24,7 +24,7 @@ module.exports = class {
         break
       case 'string':
         this.id = {
-          type: DataTypes.TEXT,
+          type: DataTypes.STRING,
           primaryKey: true
         }
         break
@@ -66,13 +66,13 @@ module.exports = class {
         //  if the schema defines a length or max value, set the field
         const lengths = attribute._tests.filter(test => test.name === 'max' || test.name === 'length')
         let length = 0;
-        let stringTypeDef = DataTypes.TEXT;
+
         if (lengths.length === 1) {
           length = lengths[0].arg
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
-        stringTypeDef = (length > 0) ? DataTypes.STRING(length) : stringTypeDef;
+        const stringTypeDef = (length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT;
         this[attributeName] = {
           type: stringTypeDef,
           allowNull: true

--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -65,13 +65,14 @@ module.exports = class {
       if (attribute._type === 'string') {
         //  if the schema defines a length or max value, set the field
         const lengths = attribute._tests.filter(test => test.name === 'max' || test.name === 'length')
-        let length
+        let length = 0;
+        let stringTypeDef = DataTypes.TEXT;
         if (lengths.length === 1) {
           length = lengths[0].arg
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
-        const stringTypeDef = (length && length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT('long');
+        stringTypeDef = (length > 0) ? DataTypes.STRING(length) : stringTypeDef;
         this[attributeName] = {
           type: stringTypeDef,
           allowNull: true

--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -24,7 +24,7 @@ module.exports = class {
         break
       case 'string':
         this.id = {
-          type: DataTypes.STRING,
+          type: DataTypes.TEXT,
           primaryKey: true
         }
         break

--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -71,8 +71,9 @@ module.exports = class {
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
+        const stringTypeDef = (length === 0) ? DataTypes.TEXT : DataTypes.STRING(length);
         this[attributeName] = {
-          type: DataTypes.STRING(length),
+          type: stringTypeDef,
           allowNull: true
         }
         for (let test of attribute._tests) {

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -78,6 +78,12 @@ module.exports = class extends Default {
           this.setDataValue(attributeName, val || {})
         }
       }
+      if (attribute._type === 'string') {
+        this[attribute] = {
+          tyoe: DataTypes.TEXT,
+          allowNull: true
+        }
+      }
     }
   }
 }

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -79,9 +79,23 @@ module.exports = class extends Default {
         }
       }
       if (attribute._type === 'string') {
-        this[attribute] = {
-          tyoe: DataTypes.TEXT,
+        //  if the schema defines a length or max value, set the field
+        const lengths = attribute._tests.filter(test => test.name === 'max' || test.name === 'length')
+        let length
+        if (lengths.length === 1) {
+          length = lengths[0].arg
+        } else if (lengths.length === 2) {
+          length = Math.max(lengths[0].arg, lengths[1].arg)
+        }
+        const stringTypeDef = (length === 0) ? DataTypes.TEXT('long') : DataTypes.STRING(length);
+        this[attributeName] = {
+          type: stringTypeDef,
           allowNull: true
+        }
+        for (let test of attribute._tests) {
+          if (test.name === 'max' || test.name === 'length') {
+            this[attributeName].type = DataTypes.STRING(test.arg)
+          }
         }
       }
     }

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -87,7 +87,7 @@ module.exports = class extends Default {
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
-        const stringTypeDef = (length === 0) ? DataTypes.TEXT('long') : DataTypes.STRING(length);
+        const stringTypeDef = (length && length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT('long');
         this[attributeName] = {
           type: stringTypeDef,
           allowNull: true

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -78,26 +78,6 @@ module.exports = class extends Default {
           this.setDataValue(attributeName, val || {})
         }
       }
-      if (attribute._type === 'string') {
-        //  if the schema defines a length or max value, set the field
-        const lengths = attribute._tests.filter(test => test.name === 'max' || test.name === 'length')
-        let length
-        if (lengths.length === 1) {
-          length = lengths[0].arg
-        } else if (lengths.length === 2) {
-          length = Math.max(lengths[0].arg, lengths[1].arg)
-        }
-        const stringTypeDef = (length && length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT;
-        this[attributeName] = {
-          type: stringTypeDef,
-          allowNull: true
-        }
-        for (let test of attribute._tests) {
-          if (test.name === 'max' || test.name === 'length') {
-            this[attributeName].type = DataTypes.STRING(test.arg)
-          }
-        }
-      }
     }
   }
 }

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -36,7 +36,7 @@ module.exports = class extends Default {
         switch (attribute._inner.items[0]._type) {
           case 'string':
             this[attributeName] = {
-              type: DataTypes.ARRAY(DataTypes.STRING),
+              type: DataTypes.ARRAY(DataTypes.TEXT),
               allowNull: true
             }
             break

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -87,7 +87,7 @@ module.exports = class extends Default {
         } else if (lengths.length === 2) {
           length = Math.max(lengths[0].arg, lengths[1].arg)
         }
-        const stringTypeDef = (length && length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT('long');
+        const stringTypeDef = (length && length > 0) ? DataTypes.STRING(length) : DataTypes.TEXT;
         this[attributeName] = {
           type: stringTypeDef,
           allowNull: true

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -36,7 +36,7 @@ module.exports = class extends Default {
         switch (attribute._inner.items[0]._type) {
           case 'string':
             this[attributeName] = {
-              type: DataTypes.ARRAY(DataTypes.TEXT),
+              type: DataTypes.ARRAY(DataTypes.STRING),
               allowNull: true
             }
             break


### PR DESCRIPTION
Adding support for Sequelize TEXT datatype.

Logic is use TEXT if min, max, or length is not set.

Was able to run the tests and it passes. 